### PR TITLE
Fixes in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Thank you for your pull request. Please review the below requirements.
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] You have read the [Contribution Guidlines](https://github.com/LoginRadius/developer-authentication-demos/blob/master/guidelines.md) before creating this PR.
-- [ ] This is not a duplicate entry for any framework or language\
+- [ ] This is not a duplicate entry for any framework or language
 
 ##### Description of change
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Thank you for your pull request. Please review the below requirements.
 
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
-- [ ] You have read the [Contribution Guidlines](https://github.com/LoginRadius/developer-authentication-demos/blob/master/guidelines.md) before creating this PR.
+- [ ] You have read the [Contribution Guidlines](https://github.com/LoginRadius/developer-authentication-demos/blob/master/contributing.md) before creating this PR.
 - [ ] This is not a duplicate entry for any framework or language.
 
 ##### Description of change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Thank you for your pull request. Please review the below requirements.
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] You have read the [Contribution Guidlines](https://github.com/LoginRadius/developer-authentication-demos/blob/master/guidelines.md) before creating this PR.
-- [ ] This is not a duplicate entry for any framework or language
+- [ ] This is not a duplicate entry for any framework or language.
 
 ##### Description of change
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You have read the [Contribution Guidlines](https://github.com/LoginRadius/developer-authentication-demos/blob/master/guidelines.md) before creating this PR.
- [x] This is not a duplicate entry for any framework or language.

##### Description of change
So Previously the `Contributing Guidelines` link was taking the users to the guidelines.md whereas I believe it should take the contributers to the Contributing.md file..
Also removed a backslash which was not needed and replaced it with a period "."
<!-- In case of a bug please provide a short description of what is changed and add link of the relevant issue after this comment-->


